### PR TITLE
First release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # zoom
-A parallel command batch executor
+Parallel command executor with a focus on simplicity and good cross-platform behaviour 
+
+## Usage
+
+    zoom <file_containing_commands>
+
+The file should contain a list of commands to be executed, one per line. For example
+
+    ping 8.8.8.8
+    ping 8.8.4.4
+
+`zoom` will spawn a `$SHELL` for each command so you can use things like `&&` and `||` 
+
+## Installation
+
+Head over to the [releases](https://github.com/pwr22/zoom/releases) page, download the binary for your operating system and put it somewhere in your `$PATH`
+
+## Why
+
+`zoom` is inspired by [rush](https://github.com/shenwei356/rush) but I needed different behaviour on command failure and found the codebase a little challenging as a newcomer so felt I couldn't add to it easily
+
+I was also interested in using Go more, and its a good language for this sort of problem so I decided to write `zoom`
+
+## See also
+
+- [rush](https://github.com/shenwei356/rush)
+- [gargs](https://github.com/brentp/gargs)

--- a/args.go
+++ b/args.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+)
+
+var parallelism = flag.Int("parallelism", 0, "how many commands to run at a time")
+
+// parse flags and commandline args
+func parseArgs() {
+	flag.Parse()
+
+	if len(flag.Args()) != 1 {
+		fmt.Fprintln(os.Stderr, "expecting a single argument - the path of the file of commands to run")
+		os.Exit(2)
+	}
+}
+
+// read in commands to run
+func getCmdStrings() []string {
+	cmdsFilePath := flag.Arg(0)
+
+	cmdsFile, err := os.Open(cmdsFilePath)
+	if err != nil {
+		panic(err)
+	}
+	defer cmdsFile.Close()
+
+	// one command per line
+	scanner := bufio.NewScanner(cmdsFile)
+	scanner.Split(bufio.ScanLines)
+
+	// slurp in all the lines
+	var lines []string
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	return lines
+}

--- a/job.go
+++ b/job.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"os/exec"
+)
+
+// a job to run a command
+type job struct {
+	cmd *exec.Cmd
+	out string
+	err error
+}

--- a/job_linux.go
+++ b/job_linux.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// create a job to run a command
+func createJob(cmdStr string) job {
+	cmd := exec.Command("sh", "-c", cmdStr)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true} // create a new process group
+	return job{cmd: cmd}
+}
+
+// stop a running job - no op if not running yet or already dead
+func (job job) stop() {
+	if job.cmd.Process != nil { // we can only do this if the process exists
+		syscall.Kill(-job.cmd.Process.Pid, syscall.SIGTERM) // take down the process group
+	}
+}

--- a/job_windows.go
+++ b/job_windows.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"syscall"
 )
@@ -37,6 +38,6 @@ func sendCtrlBreak(pid int) {
 
 	res, _, err := proc.Call(syscall.CTRL_BREAK_EVENT, uintptr(pid))
 	if res == 0 { // this seems to happen if the process is already dead so we can ignore it
-		fmt.Fprintln(err)
+		fmt.Fprintln(os.Stderr, err)
 	}
 }

--- a/job_windows.go
+++ b/job_windows.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+// create a job to run a command
+func createJob(cmdStr string) job {
+	cmd := exec.Command("cmd")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CmdLine:       fmt.Sprintf(`/C "%s"`, cmdStr),   // got to do weird things for the quoting to work right
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP, // signals go to the whole group so we gotta make a new one
+	}
+	return job{cmd: cmd}
+}
+
+// stop a running job - no op if not running yet or already dead
+func (job job) stop() {
+	if job.cmd.Process != nil { // we can only do this if the process exists
+		sendCtrlBreak(job.cmd.Process.Pid) // this goes to the whole process group and can only be sent within the same console
+	}
+}
+
+// found in the tests for go itself
+func sendCtrlBreak(pid int) {
+	dll, err := syscall.LoadDLL("kernel32.dll")
+	if err != nil {
+		panic(err)
+	}
+
+	proc, err := dll.FindProc("GenerateConsoleCtrlEvent")
+	if err != nil {
+		panic(err)
+	}
+
+	res, _, err := proc.Call(syscall.CTRL_BREAK_EVENT, uintptr(pid))
+	if res == 0 { // this seems to happen if the process is already dead so we can ignore it
+		fmt.Fprintln(err)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"os"
+)
+
+func main() {
+	parseArgs()
+	os.Exit(runCmds(getCmdStrings()))
+}

--- a/run.go
+++ b/run.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+)
+
+func runCmds(cmdStrs []string) int {
+	jobsToRun := make(chan job, len(cmdStrs)) // enough to buffer all commands
+	jobsCompleted := make(chan job, len(cmdStrs))
+
+	cmdRunner := func() {
+		for job := range jobsToRun {
+			out, err := job.cmd.CombinedOutput()
+			job.out, job.err = string(out), err
+			jobsCompleted <- job
+		}
+	}
+
+	numOfRunners := *parallelism
+	if numOfRunners == 0 {
+		numOfRunners = len(cmdStrs)
+	}
+
+	for n := 1; n <= numOfRunners; n++ { // start runners
+		go cmdRunner()
+	}
+
+	jobs := make([]job, len(cmdStrs))
+	for idx, cmdStr := range cmdStrs { // send the work
+		job := createJob(cmdStr)
+		jobs[idx] = job
+		jobsToRun <- job
+	}
+	close(jobsToRun) // everything is queued up - this signals to runners when they should finish up
+
+	doneCount, erroring, exitStatus := 0, false, 0
+	for doneCount < len(cmdStrs) {
+		job := <-jobsCompleted
+		fmt.Print(job.out)
+
+		if job.err != nil {
+			if !erroring { // kill other processes after first error - then ignore the cascade - we only care about the first error
+				fmt.Println("got an error so stopping all commands - further errors will be ignored")
+				fmt.Printf("error: %v\n", job.err)
+
+				exitStatus = 1
+				for _, job := range jobs {
+					job.stop()
+				}
+				erroring = true
+			}
+		}
+
+		doneCount++
+	}
+
+	return exitStatus
+}


### PR DESCRIPTION
Runs commands in parallel, level of `-parallelism` can be changed. It prints out all combined stdout / stderr once a command finishes whether it succeeds or not

If an error occurs with any of the commands it stops any still running. This is buggy right now as new commands will continue to be spawned and then it will have to wait for them all to finish. This is easily triggered when setting `-parallelism` to something less than the total number of commands

Works on windows and linux