### PR TITLE
Update lastJobPrinted as we print

### DIFF
--- a/run/run.go
+++ b/run/run.go
@@ -43,6 +43,7 @@ func printJobs(finishedJob *job.Job, state *runState) {
 			for idx := finishedJob.Num; idx < len(state.jobsToPrint) && state.jobsToPrint[idx] != nil; idx++ {
 				fmt.Print(state.jobsToPrint[idx].Out)
 				state.jobsToPrint[idx] = nil
+				state.lastJobPrinted = idx
 			}
 		}
 	} else { // output immediately


### PR DESCRIPTION
Before this would always sit at -1 and we'd only ever try to
print output if -k is given when the first job completes

Closes #45 